### PR TITLE
ACM-21348: Modify the rhtap image for FIPS compliance

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,9 +1,9 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 as builder
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
 ARG goproxy=https://proxy.golang.org
 ENV GOPROXY=$goproxy
-ENV GOFLAGS="-mod=readonly"
+ENV GOFLAGS="-mod=readonly -tags=strictfipsruntime"
 
 WORKDIR /workspace
 
@@ -15,10 +15,13 @@ RUN go mod download
 ARG package=.
 ARG ARCH
 ARG LDFLAGS
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags "${LDFLAGS} -extldflags '-static'"  -o manager ${package}
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=${ARCH} GOEXPERIMENT=strictfipsruntime go build -ldflags "${LDFLAGS}" -o manager ${package}
 
 # Copy the controller-manager into a thin image
-FROM registry.redhat.io/rhel9-4-els/rhel:9.4
+FROM registry.redhat.io/rhel9-6-els/rhel:9.6
+
+RUN dnf install -y openssl
+
 WORKDIR /
 COPY --from=builder /workspace/manager .
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies


### PR DESCRIPTION
**What this PR does / why we need it**:
Modify the rhtap image for FIPS compliance

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Apply FIPS compliance
```
