### PR TITLE
Fix Konflux push to build multi-arch

### DIFF
--- a/.tekton/cluster-api-provider-kubevirt-mce-29-pull-request.yaml
+++ b/.tekton/cluster-api-provider-kubevirt-mce-29-pull-request.yaml
@@ -30,6 +30,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
   - name: dockerfile
     value: Dockerfile.rhtap
   - name: path-context

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -13,14 +13,10 @@ COPY go.sum go.sum
 # Copy the sources
 COPY ./ ./
 
-# Build
-ARG ARCH=amd64
-ARG ldflags
-
 # Do not force rebuild of up-to-date packages (do not use -a) and use the compiler cache folder
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    CGO_ENABLED=1 GOOS=linux GOARCH=${ARCH} \
+    CGO_ENABLED=1 \
     go build -mod=readonly \
     -o manager .
 


### PR DESCRIPTION

**What this PR does / why we need it**:

Multi-arch image builds are failing due to the hard-coded arch setting in the dockerfile.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
