### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for cluster-api-provider-kubevirt-mce-29

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -23,7 +23,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # Copy the controller-manager into a thin image
 FROM registry.redhat.io/rhel9-6-els/rhel:9.6
 LABEL \
-    name="cluster-api-provider-kubevirt" \
+    name="multicluster-engine/cluster-api-provider-kubevirt-rhel9" \
+    cpe="cpe:/a:redhat:multicluster_engine:2.9::el9" \
     com.redhat.component="cluster-api-provider-kubevirt" \
     description="The Cluster API brings declarative Kubernetes-style APIs to cluster creation, configuration and management. The \
     API itself is shared across multiple cloud providers allowing for true Kubevirt hybrid deployments of Kubernetes." \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
