### PR TITLE
ACM-28626: Update the base image to fix Konflux EC violation

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -o manager .
 
 # Copy the controller-manager into a thin image
-FROM registry.redhat.io/rhel9-6-els/rhel:9.6
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
 LABEL \
     name="cluster-api-provider-kubevirt" \
     com.redhat.component="cluster-api-provider-kubevirt" \


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Konflux image check was failing on registry.redhat.io/rhel9-6-els/rhel, so we should switch to the standard repository path. https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/crt-redhat-acm-tenant/applications/release-mce-28/pipelineruns/cluster-api-provider-kubevirt-mce-28-on-push-wmfzv

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # https://issues.redhat.com/browse/ACM-28626

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
