### PR TITLE
ACM-33602: Use the latest ubi image

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -o manager .
 
 # Copy the controller-manager into a thin image
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 LABEL \
     name="multicluster-engine/cluster-api-provider-kubevirt-rhel9" \
     cpe="cpe:/a:redhat:multicluster_engine:2.17::el9" \


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The base image `registry.access.redhat.com/ubi9/ubi-minimal:9.6` is no longer being updated.  It is recommended to use the latest.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # https://redhat.atlassian.net/browse/ACM-33602

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
