### PR TITLE
ACM-33602: Use the latest ubi image

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -o manager .
 
 # Copy the controller-manager into a thin image
-FROM registry.redhat.io/rhel9-6-els/rhel:9.6
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 LABEL \
     name="multicluster-engine/cluster-api-provider-kubevirt-rhel9" \
     cpe="cpe:/a:redhat:multicluster_engine:2.11::el9" \


### PR DESCRIPTION
## What this PR does / why we need it
Backports the same base image update from #460 to `release-4.21`.

- switches `Dockerfile.rhtap` runtime image to `registry.access.redhat.com/ubi9/ubi-minimal:latest`

## Which issue(s) this PR fixes
fixes https://redhat.atlassian.net/browse/ACM-33602

## Special notes for your reviewer
This is a direct cherry-pick/backport of commit `da093e9` from main, resolved cleanly for `release-4.21`.

## Release notes
```release-note
NONE
```

Made with [Cursor](https://cursor.com)