### PR TITLE
ACM-33602: Use the latest ubi image

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -o manager .
 
 # Copy the controller-manager into a thin image
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 LABEL \
     name="cluster-api-provider-kubevirt" \
     com.redhat.component="cluster-api-provider-kubevirt" \


### PR DESCRIPTION
## What this PR does / why we need it
Backports the same base image update from #460.

- switches `Dockerfile.rhtap` runtime image to `registry.access.redhat.com/ubi9/ubi-minimal:latest`

## Which issue(s) this PR fixes
fixes https://redhat.atlassian.net/browse/ACM-33602

## Special notes for your reviewer
This is a direct cherry-pick/backport of commit `da093e9`, resolved cleanly for this release branch.

## Release notes
```release-note
NONE
```

Made with [Cursor](https://cursor.com)