### PR TITLE
OCPBUGS-98061: [release-4.20] fix: clear FailureReason/FailureMessage when VM recovers from terminal state

### DIFF
--- a/controllers/kubevirtmachine_controller.go
+++ b/controllers/kubevirtmachine_controller.go
@@ -259,6 +259,9 @@ func (r *KubevirtMachineReconciler) reconcileNormal(ctx *context.MachineContext)
 		failureErr := capierrors.UpdateMachineError
 		ctx.KubevirtMachine.Status.FailureReason = &failureErr
 		ctx.KubevirtMachine.Status.FailureMessage = &terminalReason
+	} else {
+		ctx.KubevirtMachine.Status.FailureReason = nil
+		ctx.KubevirtMachine.Status.FailureMessage = nil
 	}
 
 	// Provision the underlying VM if not existing

--- a/controllers/kubevirtmachine_controller_test.go
+++ b/controllers/kubevirtmachine_controller_test.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/kubevirt"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -757,6 +758,58 @@ var _ = Describe("reconcile a kubevirt machine", func() {
 		Expect(machineContext.KubevirtMachine.Status.FailureReason).ToNot(BeNil())
 		Expect(machineContext.KubevirtMachine.Status.FailureMessage).ToNot(BeNil())
 		Expect(*machineContext.KubevirtMachine.Status.FailureMessage).To(Equal("VMI has reached a permanent finalized state"))
+	})
+
+	It("When VM recovers from terminal state it should clear FailureReason and FailureMessage", func() {
+		// Simulate a KubevirtMachine that previously had a terminal failure
+		// (e.g., VM was stopped with RunStrategyHalted, then started back with RunStrategyAlways)
+		failureErr := capierrors.UpdateMachineError
+		failureMsg := "VMI has reached a permanent finalized state"
+		kubevirtMachine.Status.FailureReason = &failureErr
+		kubevirtMachine.Status.FailureMessage = &failureMsg
+
+		vmi.Status.Conditions = []kubevirtv1.VirtualMachineInstanceCondition{
+			{
+				Type:   kubevirtv1.VirtualMachineInstanceReady,
+				Status: corev1.ConditionTrue,
+			},
+			{
+				Type:   kubevirtv1.VirtualMachineInstanceIsMigratable,
+				Status: corev1.ConditionTrue,
+			},
+		}
+		vmi.Status.Interfaces = []kubevirtv1.VirtualMachineInstanceNetworkInterface{
+			{
+				IP: "10.200.36.200",
+			},
+		}
+		vmi.Status.Phase = kubevirtv1.Running
+
+		// VM now has RunStrategyAlways (recovered)
+		runStrategy := kubevirtv1.RunStrategyAlways
+		vm.Spec.RunStrategy = &runStrategy
+
+		objects := []client.Object{
+			cluster,
+			kubevirtCluster,
+			machine,
+			kubevirtMachine,
+			sshKeySecret,
+			bootstrapSecret,
+			bootstrapUserDataSecret,
+			vm,
+			vmi,
+		}
+
+		setupClient(kubevirt.DefaultMachineFactory{}, objects)
+
+		infraClusterMock.EXPECT().GenerateInfraClusterClient(kubevirtMachine.Spec.InfraClusterSecretRef, kubevirtMachine.Namespace, machineContext.Context).Return(fakeClient, kubevirtMachine.Namespace, nil)
+
+		_, err := kubevirtMachineReconciler.reconcileNormal(machineContext)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(machineContext.KubevirtMachine.Status.FailureReason).To(BeNil())
+		Expect(machineContext.KubevirtMachine.Status.FailureMessage).To(BeNil())
+		Expect(machineContext.KubevirtMachine.Status.Ready).To(BeTrue())
 	})
 
 	Context("update kubevirt machine conditions correctly", func() {


### PR DESCRIPTION
When a KubeVirt VM is stopped (runStrategy changed to Halted), the VMI reaches a finalized state and IsTerminal() correctly sets FailureReason on the KubevirtMachine. However, when the VM is started back (runStrategy changed to Always), IsTerminal() returns false but the FailureReason/FailureMessage fields are never cleared.

This causes the CAPI Machine phase to stay stuck at "Failed" even though all Machine conditions (Ready, InfrastructureReady, NodeHealthy) are True. Downstream consumers that rely on the Machine phase (such as HyperShift's endpointslice reconciler) then permanently mark endpoints as not ready, breaking ingress into hosted clusters.

The fix adds an else clause to nil out FailureReason and FailureMessage when IsTerminal() returns false, allowing VMs to properly recover.

(cherry picked from commit 2d4d7e38355cfd9110c3f5e7cf4906fffac52026)

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release notes**: